### PR TITLE
fix: apply css overrides to all pages

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -8,7 +8,8 @@ const config = {
   title: "HMS Bambi",
   description: "A collection of Harvard Medical School scientists interested in applying our technical skills to support local minority-owned/serving organizations.",
   head: [
-    ["link", { rel: "icon", href: '/logo.svg' }]
+    ["link", { rel: "icon", href: '/logo.svg' }],
+    ["link", { rel: "stylesheet", href: '/index.css' }],
   ],
   themeConfig: {
     socialLinks: [

--- a/src/index.md
+++ b/src/index.md
@@ -24,12 +24,3 @@ features:
   - title: ⚒️ Projects
     details: Possible projects might include, redesigning or creating a website, visualizing internal data, developing spreadsheets to track organizational data.
 ---
-
-<style>
-  :root {
-    --vp-c-brand: var(--vp-c-red);
-    --vp-c-brand-light: var(--vp-c-red-light);
-    --vp-c-brand-lighter: var(--vp-c-red-lighter);
-    --vp-c-brand-dark: var(--vp-c-red-dark);
-  }
-</style>

--- a/src/public/index.css
+++ b/src/public/index.css
@@ -1,0 +1,6 @@
+:root {
+  --vp-c-brand: var(--vp-c-red);
+  --vp-c-brand-light: var(--vp-c-red-light);
+  --vp-c-brand-lighter: var(--vp-c-red-lighter);
+  --vp-c-brand-dark: var(--vp-c-red-dark);
+}


### PR DESCRIPTION
This PR adds the `src/public/index.css` to the head of every page. This makes it so that the "red" theming is correct for all pages.
