### PR TITLE
feat: add testimonials page

### DIFF
--- a/src/.vitepress/config.js
+++ b/src/.vitepress/config.js
@@ -6,7 +6,7 @@
 const config = {
   lang: "en-US",
   title: "HMS Bambi",
-  description: "A collection of Harvard Medical School scientists interested in applying our technical skills to support local minority-owned/serving organizations.",
+  description: "A collection of Harvard Medical School scientists interested in volunteering our technical skills to support local minority-owned/serving organizations.",
   head: [
     ["link", { rel: "icon", href: '/logo.svg' }],
     ["link", { rel: "stylesheet", href: '/index.css' }],
@@ -19,6 +19,7 @@ const config = {
     nav: [
       { text: 'Contact', link: '/contact' },
       { text: 'Team', link: '/team' },
+      { text: 'Testimonials', link: '/testimonials' },
     ],
     editLink: {
       pattern: 'https://github.com/hms-bambi/hms-bambi.github.io/edit/main/src/:path'

--- a/src/contact.md
+++ b/src/contact.md
@@ -1,3 +1,3 @@
-# 😅 oops!
+# Contact
 
-This page is a work in progress. Check back soon!
+😅 oops! This page is a work in progress. Check back soon!

--- a/src/index.md
+++ b/src/index.md
@@ -13,9 +13,6 @@ hero:
       text: Contact
       link: /contact
     - theme: alt
-      text: Team
-      link: /team
-    - theme: alt
       text: Testimonials
       link: /testimonials
 

--- a/src/index.md
+++ b/src/index.md
@@ -15,6 +15,9 @@ hero:
     - theme: alt
       text: Team
       link: /team
+    - theme: alt
+      text: Testimonials
+      link: /testimonials
 
 features:
   - title: 🚀 Goal

--- a/src/testimonials.md
+++ b/src/testimonials.md
@@ -1,3 +1,3 @@
-# 😅 oops!
+# Testimonials
 
-This page is a work in progress. Check back soon!
+😅 oops! This page is a work in progress. Check back soon!

--- a/src/testimonials.md
+++ b/src/testimonials.md
@@ -1,0 +1,3 @@
+# 😅 oops!
+
+This page is a work in progress. Check back soon!


### PR DESCRIPTION
Tried to add testimonials page but now when navigating to the /contact page it highlights 'Testimonials' in the topnav